### PR TITLE
Funcionalide de Gerar PDF

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ Requests==2.32.3
 streamlit==1.44.1
 ipeadatapy==0.1.9
 supabase==2.15.2
+matplotlib==3.10.3
+xhtml2pdf==0.2.17
+markdown==3.8

--- a/src/services/pdf.py
+++ b/src/services/pdf.py
@@ -1,0 +1,66 @@
+import matplotlib.pyplot as plt
+import tempfile
+import pandas as pd
+from xhtml2pdf import pisa
+import markdown
+
+def gerar_PDF(codSerie: str, dfSerie: pd.DataFrame, iaText: str):
+    """
+    :arg codSerie: código da série do IPEA
+    :arg dfSerie: dataframe da série do IPEA
+    :arg iaText: relatório em markdown gerado pelo DeepSeek
+
+    :return retorna um PDF criado com base nos dados informados sobre a série do IPEA
+    """
+
+    if codSerie == "" or dfSerie.empty or iaText == "":
+        raise Exception("Parametros insuficientes.")
+
+    # Preparar dataframe para o gráfico
+    dataframe = pd.DataFrame(dict(VALUE=dfSerie.iloc[:, -1]))
+
+    # Criar gráfico matplotlib
+    fig, ax = plt.subplots()
+    ax.plot(dataframe.index, dataframe["VALUE"])
+    ax.set_xlabel("data")
+    ax.set_ylabel("valor")
+
+    # Salvar imagem do gráfico em arquivo temporário
+    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp_img:
+        fig.savefig(tmp_img.name)
+        img_path = tmp_img.name
+
+    # Converter markdown do iaText para HTML
+    ia_html = markdown.markdown(iaText)
+
+    # Criar HTML completo para o PDF com CSS atualizado
+    html = f"""
+            <html>
+                <head>
+                    <style>
+                        h1, h3, h4, body, p {{font-family: Helvetica; color: black;}}
+                        h1 {{ font-size: 36px; }}
+                        h3 {{ font-size: 24px; }}
+                        h4 {{ font-size: 20px; }}
+                        body, p {{ margin: 30px; font-size: 16px; line-height: 1.5; }}
+                        img {{ max-width: 100%; height: auto; margin: 20px 0; }}
+                    </style>
+                </head>
+                <body>
+                    <h1>GovInsights</h1>
+                    <h3>Dados da Série {codSerie} do IPEA</h3>
+                    <img src="{img_path}"/>
+                    {ia_html}
+                </body>
+            </html>
+            """
+
+    # Salvar PDF em arquivo temporário
+    with tempfile.NamedTemporaryFile(suffix=".pdf", delete=False) as tmp_pdf:
+        pdf_path = tmp_pdf.name
+        pisa_status = pisa.CreatePDF(html, dest=tmp_pdf)
+
+    if pisa_status.err:
+        raise Exception("PDF não foi gerado.")
+
+    return pdf_path


### PR DESCRIPTION
# Descrição  

Foi definido as tecnologias para gerar o PDF:

Biblioteca `xhtml2pdf`: Biblioteca principal que converte html para PDF.
Biblioteca `markdown`: Biblioteca que converte markdown para html, utilizada no texto gerado por IA.
Biblioteca `matplotlib`: Biblioteca que gera o gráfico com base no dataframe da série escolhida.

O PDF é gerado com base no dataframe e relatório gerado por IA da série financeira escolhida pelo usuário.

A funcionalidade retorna um PDF que pode ser baixado utilizando funcionalidades do Streamlit.

Corrige #121 

## Tipo de Mudança  

📌 **Prioridade:** 🔴 Alta

Por favor, marque as opções relevantes:  

- [ ] 🐞 **Correção de bug** (mudança que não quebra o sistema e resolve um problema)  
- [x] ✨ **Nova funcionalidade** (mudança que não quebra o sistema e adiciona uma nova funcionalidade)  
- [ ] ⚠️ **Mudança que quebra o sistema** (correção ou funcionalidade que pode fazer com que a funcionalidade existente não funcione como esperado)  
- [ ] 📚 **Atualização de documentação**  

## Checklist  

- [x] Meu código segue as diretrizes de estilo deste projeto  
- [x] Eu revisei meu próprio código  
- [x] Comentei meu código, especialmente em áreas de difícil compreensão  
- [ ] Fiz mudanças correspondentes na documentação  
- [x] Minhas mudanças não geram novos avisos  
