### PR TITLE
Frontend - Correção da cor de fundo dos gráficos

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -9,11 +9,13 @@ weight = 500
 
 
 [[theme.fontFaces]]
-family = "Inter Black"
+family = "Inter Bold"
 url = "app/static/font/Inter-VariableFont.ttf"
-weight = 900
+weight = 600
 
 [theme]
 font = "Inter"
-headingFont = "Inter Black"
+headingFont = "Inter Bold"
 primaryColor = "#2BB17A"
+backgroundColor = "#0F1020"
+textColor = "#FFFfFF"

--- a/src/interface/views/assets/stylesheets/style.css
+++ b/src/interface/views/assets/stylesheets/style.css
@@ -1,18 +1,3 @@
-body, .stApp {
-    background-color: #0F1020; /*cor do fundo*/
-    font-family: 'Segoe UI', sans-serif;
-    color: #ffffff; /*tetxo do tipulo*/
-    opacity: 0.9; 
-}
-
-
-body, .stApp {
-    background-color: #0F1020;
-    font-family: 'Segoe UI', sans-serif;
-    color: #ffffff;
-    /* opacity: 0.9; */
-}
-
 /*  SIDEBAR  */
 section[data-testid="stSidebar"] {
     background: rgba(10, 65, 97, 0.171); /* Levemente azul  translúcido */
@@ -24,13 +9,10 @@ section[data-testid="stSidebar"] {
     transition: all 0.3s ease;
 }
 
-
 section[data-testid="stSidebar"] .block-container {
     padding: 2rem 1rem;
     color: white; /* ou ajuste conforme seu tema */
 }
-
-
 
 /* Título da sidebar */
 section[data-testid="stSidebar"] h1 {


### PR DESCRIPTION
# Descrição  

Ajusta cores de tema pela config.toml do Streamlit para corrigir cor de fundo dos gráficos, evitando adição de código à graph.py. Remove, também, código redundante no CSS (relacionados a cor de fundo). Corrige, também, cor dos textos + Ajusta weight da fonte das headings para se assemelhar ao protótipo do Figma

## Tipo de Mudança  

📌 **Prioridade:**🟢 Baixa  

Por favor, marque as opções relevantes:  

- [X] 🐞 **Correção de bug** (mudança que não quebra o sistema e resolve um problema)  
- [ ] ✨ **Nova funcionalidade** (mudança que não quebra o sistema e adiciona uma nova funcionalidade)  
- [ ] ⚠️ **Mudança que quebra o sistema** (correção ou funcionalidade que pode fazer com que a funcionalidade existente não funcione como esperado)  
- [ ] 📚 **Atualização de documentação**  

## Checklist  

- [X] Meu código segue as diretrizes de estilo deste projeto  
- [X] Eu revisei meu próprio código  
- [ ] Comentei meu código, especialmente em áreas de difícil compreensão  
- [ ] Fiz mudanças correspondentes na documentação  
- [X] Minhas mudanças não geram novos avisos  
