### PR TITLE
fix(tests): corrigir mocks dos testes unitários

### DIFF
--- a/tests/unit/test_ia_unit.py
+++ b/tests/unit/test_ia_unit.py
@@ -13,7 +13,7 @@ def test_gerar_relatorio_parametros_invalidos():
         gerar_relatorio("", df)
 
 
-@patch("src.services.ia.Together")
+@patch("together.Together")
 def test_gerar_relatorio_sucesso(mock_together):
     df = pd.DataFrame({"ano": range(2000, 2100), "valor": [i for i in range(100)]})
     df.index.name = "ano"
@@ -30,7 +30,7 @@ def test_gerar_relatorio_sucesso(mock_together):
     assert resultado == "Relatório gerado pela IA."
 
 
-@patch("src.services.ia.Together", side_effect=Exception("Falha de rede"))
+@patch("together.Together", side_effect=Exception("Falha de rede"))
 def test_gerar_relatorio_erro_api(mock_together):
     df = pd.DataFrame({"ano": range(2000, 2100), "valor": [i for i in range(100)]})
     df.index.name = "ano"
@@ -41,7 +41,7 @@ def test_gerar_relatorio_erro_api(mock_together):
 
 # NOVOS TESTES ADICIONADOS
 
-@patch("src.services.ia.Together")
+@patch("together.Together")
 def test_gerar_relatorio_formatacao_prompt(mock_together):
     df = pd.DataFrame({"ano": [2020, 2021], "valor": [100, 200]})
     df.index.name = "ano"
@@ -55,18 +55,17 @@ def test_gerar_relatorio_formatacao_prompt(mock_together):
     mock_together.return_value = mock_client
 
     # Captura o conteúdo enviado no prompt
-    with patch("src.services.ia.re") as mock_re:
-        gerar_relatorio("SERIE123", df)
+    gerar_relatorio("SERIE123", df)
 
-        args = mock_client.chat.completions.create.call_args[1]
-        prompt = args["messages"][0]["content"]
-        assert "SERIE123" in prompt
-        assert "Segue os dados da série no formato CSV:" in prompt
-        assert "Resumo sobre o que se trata a série" in prompt
-        assert "ano,valor" in prompt
+    args = mock_client.chat.completions.create.call_args[1]
+    prompt = args["messages"][0]["content"]
+    assert "SERIE123" in prompt
+    assert "Segue os dados da série no formato CSV:" in prompt
+    assert "Resumo sobre o que se trata a série" in prompt
+    assert "ano,valor" in prompt
 
 
-@patch("src.services.ia.Together")
+@patch("together.Together")
 def test_gerar_relatorio_processamento_dataframe(mock_together):
     df = pd.DataFrame({
         "valor": list(range(150))
@@ -91,8 +90,8 @@ def test_gerar_relatorio_processamento_dataframe(mock_together):
     assert str(df.index[-1].date()) in prompt
 
 
-@patch("src.services.ia.Together")
-def test_gerar_relatorio_processamento_dataframe(mock_together):
+@patch("together.Together")
+def test_gerar_relatorio_ordenacao_csv_dataframe(mock_together):
     import re
 
     df = pd.DataFrame({
@@ -138,7 +137,7 @@ def test_gerar_relatorio_dados_especiais():
     df.index.name = "índice"
 
     # Validação - Se a função lida com isso sem travar
-    with patch("src.services.ia.Together") as mock_together:
+    with patch("together.Together") as mock_together:
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_choice = MagicMock()

--- a/tests/unit/test_pdf_unit.py
+++ b/tests/unit/test_pdf_unit.py
@@ -44,10 +44,10 @@ def test_gerar_pdf_raises_exception_on_invalid_params():
         pdf.gerar_pdf("COD", pd.DataFrame(), "texto")
 
 
-@patch("src.services.pdf.pd.DataFrame.plot")  # evitar plot real
-@patch("src.services.pdf.plt.subplots")
-@patch("src.services.pdf.pisa.CreatePDF")
-@patch("src.services.pdf.markdown.markdown")
+@patch("pandas.DataFrame.plot")  # evitar plot real
+@patch("matplotlib.pyplot.subplots")
+@patch("xhtml2pdf.pisa.CreatePDF")
+@patch("markdown.markdown")
 def test_gerar_pdf_success(mock_md, mock_pisa, mock_subplots, mock_plot, temp_files):
     import src.services.pdf as pdf
 
@@ -61,7 +61,7 @@ def test_gerar_pdf_success(mock_md, mock_pisa, mock_subplots, mock_plot, temp_fi
     mock_subplots.return_value = (mock_fig, mock_ax)
     mock_fig.savefig = MagicMock()
 
-    with patch("src.services.pdf.tempfile.NamedTemporaryFile", side_effect=fake_tempfile_factory(tmp_img_name, tmp_pdf_name)):
+    with patch("tempfile.NamedTemporaryFile", side_effect=fake_tempfile_factory(tmp_img_name, tmp_pdf_name)):
         df = pd.DataFrame({"valores": [1, 2, 3, 4]})
         caminho_pdf = pdf.gerar_pdf("COD123", df, "Texto em markdown")
 
@@ -72,7 +72,7 @@ def test_gerar_pdf_success(mock_md, mock_pisa, mock_subplots, mock_plot, temp_fi
         mock_pisa.assert_called_once()
 
 
-@patch("src.services.pdf.pisa.CreatePDF")
+@patch("xhtml2pdf.pisa.CreatePDF")
 def test_gerar_pdf_raises_exception_on_pdf_error(mock_pisa, temp_files):
     import src.services.pdf as pdf
 
@@ -80,14 +80,14 @@ def test_gerar_pdf_raises_exception_on_pdf_error(mock_pisa, temp_files):
 
     mock_pisa.return_value = MagicMock(err=True)
 
-    with patch("src.services.pdf.tempfile.NamedTemporaryFile", side_effect=fake_tempfile_factory(tmp_img_name, tmp_pdf_name)):
+    with patch("tempfile.NamedTemporaryFile", side_effect=fake_tempfile_factory(tmp_img_name, tmp_pdf_name)):
         df = pd.DataFrame({"valores": [1, 2, 3]})
 
         with pytest.raises(Exception, match="PDF não foi gerado."):
             pdf.gerar_pdf("COD", df, "Texto")
 
 
-@patch("src.services.pdf.plt.subplots")
+@patch("matplotlib.pyplot.subplots")
 def test_gerar_pdf_handles_dataframe_plotting_error(mock_subplots, temp_files):
     import src.services.pdf as pdf
 
@@ -101,17 +101,17 @@ def test_gerar_pdf_handles_dataframe_plotting_error(mock_subplots, temp_files):
     # Simular erro em ax.plot, pois é ele que gera gráfico
     mock_ax.plot.side_effect = Exception("Erro no plot")
 
-    with patch("src.services.pdf.tempfile.NamedTemporaryFile", side_effect=fake_tempfile_factory(tmp_img_name, tmp_pdf_name)):
+    with patch("tempfile.NamedTemporaryFile", side_effect=fake_tempfile_factory(tmp_img_name, tmp_pdf_name)):
         df = pd.DataFrame({"valores": [1, 2, 3]})
 
         with pytest.raises(Exception, match="Erro no plot"):
             pdf.gerar_pdf("COD", df, "texto")
 
 
-@patch("src.services.pdf.pd.DataFrame.plot")
-@patch("src.services.pdf.plt.subplots")
-@patch("src.services.pdf.pisa.CreatePDF")
-@patch("src.services.pdf.markdown.markdown")
+@patch("pandas.DataFrame.plot")
+@patch("matplotlib.pyplot.subplots")
+@patch("xhtml2pdf.pisa.CreatePDF")
+@patch("markdown.markdown")
 def test_gerar_pdf_handles_markdown_conversion_error(mock_md, mock_pisa, mock_subplots, mock_plot, temp_files):
     import src.services.pdf as pdf
 
@@ -126,7 +126,7 @@ def test_gerar_pdf_handles_markdown_conversion_error(mock_md, mock_pisa, mock_su
     # Simular exceção na conversão markdown -> html
     mock_md.side_effect = Exception("Erro markdown")
 
-    with patch("src.services.pdf.tempfile.NamedTemporaryFile", side_effect=fake_tempfile_factory(tmp_img_name, tmp_pdf_name)):
+    with patch("tempfile.NamedTemporaryFile", side_effect=fake_tempfile_factory(tmp_img_name, tmp_pdf_name)):
         df = pd.DataFrame({"valores": [1, 2, 3]})
 
         with pytest.raises(Exception, match="Erro markdown"):


### PR DESCRIPTION
# Descrição  

Correção dos mocks nos testes unitários para os módulos de IA e PDF. Os testes estavam falhando porque os mocks estavam apontando para imports que não existiam no nível do módulo (`src.services.ia.Together`, `src.services.pdf.markdown`, etc.), quando na verdade esses imports são feitos dentro das funções.

**Mudanças realizadas:**
- Corrigiu os patches de `src.services.ia.Together` para `together.Together` nos testes de IA
- Corrigiu os patches de `src.services.pdf.markdown`, `src.services.pdf.pisa`, `src.services.pdf.plt` para `markdown.markdown`, `xhtml2pdf.pisa.CreatePDF`, `matplotlib.pyplot.subplots` nos testes de PDF
- Corrigiu patches de `src.services.pdf.tempfile.NamedTemporaryFile` para `tempfile.NamedTemporaryFile`
- Removeu patch desnecessário do módulo `re` no teste de formatação de prompt

Isso resolve os erros de `AttributeError` que estavam impedindo a execução dos testes no CI/CD.

Corrige # (issue relacionada aos testes falhando)

## Tipo de Mudança  

📌 **Prioridade:** 🔴 Alta  

Por favor, marque as opções relevantes:  

- [x] 🐞 **Correção de bug** (mudança que não quebra o sistema e resolve um problema)  
- [ ] ✨ **Nova funcionalidade** (mudança que não quebra o sistema e adiciona uma nova funcionalidade)  
- [ ] ⚠️ **Mudança que quebra o sistema** (correção ou funcionalidade que pode fazer com que a funcionalidade existente não funcione como esperado)  
- [ ] 📚 **Atualização de documentação**  

## Checklist  

- [x] Meu código segue as diretrizes de estilo deste projeto  
- [x] Eu revisei meu próprio código  
- [x] Comentei meu código, especialmente em áreas de difícil compreensão  
- [ ] Fiz mudanças correspondentes na documentação  
- [x] Minhas mudanças não geram novos